### PR TITLE
Fixes to get the basic example to run

### DIFF
--- a/covfee/cli/commands/launch.py
+++ b/covfee/cli/commands/launch.py
@@ -15,7 +15,7 @@ from flask import current_app as app
 from flask.cli import FlaskGroup, pass_script_info
 
 from covfee.server.app import create_app
-from ...loader import Loader
+from covfee.loader import Loader
 from covfee.launcher import Launcher, ProjectExistsException
 from halo.halo import Halo
 from covfee.shared.validator.validation_errors import JavascriptError, ValidationError

--- a/covfee/shared/dataclass.py
+++ b/covfee/shared/dataclass.py
@@ -127,6 +127,6 @@ class CovfeeApp(BaseDataclass):
 
     def launch(self, num_instances=1):
         orm_projects = self.get_instantiated_projects(num_instances)
-        l = launcher.Launcher("dev", orm_projects, folder=None)
+        l = launcher.Launcher("dev", orm_projects, folder="./")
         l.make_database()
         l.launch()

--- a/docs/docs/development.mdx
+++ b/docs/docs/development.mdx
@@ -12,7 +12,7 @@ Covfee runs on **Linux, Mac OS X and Windows**, but you are more likely to encou
 
 Covfee's frontend is built using [webpack](https://webpack.js.org/), which has a convenient [hot-reloading development server](https://webpack.js.org/guides/development/). The [Flask server](https://flask.palletsprojects.com/en/2.0.x/) used for the backend also supports reloading on changes. This guide will get you to run backend and frontend development servers:
 
-1. Install the latest version of [node.js](https://nodejs.org/en/download/). Make sure that the `npm` command is available in your terminal.
+1. Install the [node.js](https://nodejs.org/en/download/) version `16.x`. Make sure that the `npm` command is available in your terminal.
 
 
 

--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -12,8 +12,8 @@ Covfee runs on **Linux, Mac OS X and Windows**, but you are more likely to encou
 
 The only prerequisites for installing Covfee locally are Python 3 and Node.js:
 
-- [Python 3 (>= 3.6)](https://www.python.org/downloads/)
-- [Node.js](https://nodejs.org/en/). Make sure that the `npm` command is available in your terminal.
+- [Python 3 (>= 3.6, <= 3.10)](https://www.python.org/downloads/)
+- [Node.js (== 16)](https://nodejs.org/en/). Make sure that the `npm` command is available in your terminal.
 
 ### Setup
 

--- a/samples/basic/basic.py
+++ b/samples/basic/basic.py
@@ -1,5 +1,6 @@
 # from covfee import Task, HIT
 from covfee import Project, HIT, Journey, tasks
+from covfee.shared.dataclass import CovfeeApp
 from covfee.config import config
 
 config.load_environment("local")
@@ -81,4 +82,6 @@ nodes = [
 j1 = linear.add_journey(nodes)
 
 project = Project("My Project", email="example@example.com", hits=[hit, linear])
-project.launch()
+
+app = CovfeeApp([project])
+app.launch()


### PR DESCRIPTION
A few more fixes to get the code to run. With this I was able to get a basic example to run almost without crashing.

The scripts don't crash if run with ` covfee make ./basic.py` and the `covfee start --dev` doesn't seem to be needed anymore. However the website crashes with `Unexpected Application Error!`